### PR TITLE
Cleanup unused imports

### DIFF
--- a/src/vaadin-list-box.html
+++ b/src/vaadin-list-box.html
@@ -5,12 +5,10 @@ This program is available under Apache License Version 2.0, available at https:/
 -->
 
 <link rel="import" href="../../polymer/polymer-element.html">
-<link rel="import" href="../../polymer/lib/utils/render-status.html">
-<link rel="import" href="../../polymer/lib/utils/flattened-nodes-observer.html">
-
 <link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
 <link rel="import" href="../../vaadin-list-mixin/vaadin-list-mixin.html">
 <link rel="import" href="../../vaadin-element-mixin/vaadin-element-mixin.html">
+
 <dom-module id="vaadin-list-box">
   <template>
     <style>


### PR DESCRIPTION
- `FlattenedNodesObserver` is now imported in `vaadin-list-mixin` where is is actually used
- `RenderStatus` is not used at all