### PR TITLE
Workaround selected item icon not shown in IE11

### DIFF
--- a/theme/lumo/vaadin-list-box-styles.html
+++ b/theme/lumo/vaadin-list-box-styles.html
@@ -34,6 +34,11 @@
         padding-right: calc(var(--lumo-space-l) + var(--lumo-border-radius) / 4);
       }
 
+      /* Workaround to display checkmark in IE11 when list-box is not used in dropdown-menu */
+      [part="items"] ::slotted(vaadin-item)::before {
+        display: var(--_lumo-item-selected-icon-display);
+      }
+
       /* Hovered item */
       /* TODO a workaround until we have "focus-follows-mouse". After that, use the hover style for focus-ring as well */
 


### PR DESCRIPTION
Fixes #38 

Depends on vaadin/vaadin-list-mixin#42

For some reason, in IE11 items do not pick up the CSS custom property defined on the list-box element. This change workarounds that, without it `::before` pseudo elements never appear.

Note that this also needs calling `updateStyles()`: without that, the original issue on the GIF happens IE11 (`::before` pseudo elements only appear on hover).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-list-box/43)
<!-- Reviewable:end -->
