### PR TITLE
Update focus styles to support `focus-follows-mouse`

### DIFF
--- a/demo/list-box-basic-demos.html
+++ b/demo/list-box-basic-demos.html
@@ -10,12 +10,24 @@
     <vaadin-demo-snippet id='list-box-basic-demos-basic'>
       <template preserve-content>
         <vaadin-list-box>
-          <b>Register to a Run Event</b>
-          <vaadin-item>5k</vaadin-item>
-          <vaadin-item disabled>10k (sold out)</vaadin-item>
+          <vaadin-item>Option one</vaadin-item>
+          <vaadin-item disabled>Option two (disabled)</vaadin-item>
           <hr>
-          <vaadin-item>Half marathon</vaadin-item>
-          <vaadin-item>Marathon</vaadin-item>
+          <vaadin-item>Option three</vaadin-item>
+          <vaadin-item>Option four</vaadin-item>
+        </vaadin-list-box>
+      </template>
+    </vaadin-demo-snippet>
+
+    <h3>Focus Follows Mouse</h3>
+    <vaadin-demo-snippet id='list-box-basic-demos-focus-follows-mouse'>
+      <template preserve-content>
+        <vaadin-list-box focus-follows-mouse>
+          <vaadin-item>Option one</vaadin-item>
+          <vaadin-item disabled>Option two (disabled)</vaadin-item>
+          <hr>
+          <vaadin-item>Option three</vaadin-item>
+          <vaadin-item>Option three</vaadin-item>
         </vaadin-list-box>
       </template>
     </vaadin-demo-snippet>

--- a/theme/lumo/vaadin-list-box-styles.html
+++ b/theme/lumo/vaadin-list-box-styles.html
@@ -39,26 +39,14 @@
         display: var(--_lumo-item-selected-icon-display);
       }
 
-      /* Hovered item */
-      /* TODO a workaround until we have "focus-follows-mouse". After that, use the hover style for focus-ring as well */
-
-      [part="items"] ::slotted(vaadin-item:hover:not([disabled])) {
+      /* Focused item */
+      [part="items"] ::slotted([focused]:not([disabled])) {
         background-color: var(--lumo-primary-color-10pct);
       }
 
-      /* Focused item */
-
-      [part="items"] ::slotted([focus-ring]:not([disabled])) {
-        box-shadow: inset 0 0 0 2px var(--lumo-primary-color-50pct);
-      }
-
       @media (pointer: coarse) {
-        [part="items"] ::slotted(vaadin-item:hover:not([disabled])) {
+        [part="items"] ::slotted([focused]:not([disabled])) {
           background-color: transparent;
-        }
-
-        [part="items"] ::slotted([focus-ring]:not([disabled])) {
-          box-shadow: none;
         }
       }
 


### PR DESCRIPTION
connects to https://github.com/vaadin/vaadin-list-box/issues/14

Remove item hover style.

Add an example for `focus-follows-mouse`.

Depends on https://github.com/vaadin/vaadin-list-mixin/pull/43

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-list-box/46)
<!-- Reviewable:end -->