### PR TITLE
Add check for vaadin-item import

### DIFF
--- a/src/vaadin-list-box.html
+++ b/src/vaadin-list-box.html
@@ -92,10 +92,7 @@ This program is available under Apache License Version 2.0, available at https:/
           super.ready();
           this.setAttribute('role', 'list');
 
-          this._debouncerCheckImport = Polymer.Debouncer.debounce(
-            this._debouncerCheckImport,
-            Polymer.Async.timeOut.after(2000),
-            this._checkImport.bind(this));
+          setTimeout(this._checkImport.bind(this), 2000);
         }
 
         get _scrollerElement() {

--- a/src/vaadin-list-box.html
+++ b/src/vaadin-list-box.html
@@ -91,10 +91,22 @@ This program is available under Apache License Version 2.0, available at https:/
         ready() {
           super.ready();
           this.setAttribute('role', 'list');
+
+          this._debouncerCheckImport = Polymer.Debouncer.debounce(
+            this._debouncerCheckImport,
+            Polymer.Async.timeOut.after(2000),
+            this._checkImport.bind(this));
         }
 
         get _scrollerElement() {
           return this.shadowRoot.querySelector('[part="items"]');
+        }
+
+        _checkImport() {
+          var item = this.querySelector('vaadin-item');
+          if (item && !(item instanceof Polymer.Element)) {
+            console.warn(`Make sure you have imported the vaadin-item element.`);
+          }
         }
       }
 

--- a/test/import-warning-test.html
+++ b/test/import-warning-test.html
@@ -22,30 +22,30 @@
 
   <script>
     describe(`import warning for vaadin-item`, () => {
+      let listbox;
+
       function isV2() {
         return window['Polymer'] && window['Polymer']['version'] && window['Polymer']['version'].indexOf('2') === 0;
       }
 
-      beforeEach(() => fixture('default'));
+      beforeEach(() => listbox = fixture('default'));
 
-      it('should warn if not imported', done => {
+      it('should warn if not imported', () => {
         sinon.stub(console, 'warn');
-        setTimeout(() => {
-          expect(console.warn.callCount).to.equal(1);
-          console.warn.restore();
-          done();
-        }, 2001);
+        // Emulate setTimeout run from ready
+        listbox._checkImport();
+        expect(console.warn.callCount).to.equal(1);
+        console.warn.restore();
       });
 
       it('should not warn for present import', (done) => {
         if (isV2()) {
           Polymer.Base.importHref(`../../vaadin-item/vaadin-item.html`, () => {
             sinon.stub(console, 'warn');
-            setTimeout(() => {
-              expect(console.warn.called).to.be.false;
-              console.warn.restore();
-              done();
-            }, 2001);
+            listbox._checkImport();
+            expect(console.warn.called).to.be.false;
+            console.warn.restore();
+            done();
           });
         } else {
           // importHref is removed in Polymer 3 stable release, skip the test.

--- a/test/import-warning-test.html
+++ b/test/import-warning-test.html
@@ -1,0 +1,57 @@
+<!doctype html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>vaadin-list-box tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../../polymer/polymer.html">
+  <link rel="import" href="../vaadin-list-box.html">
+</head>
+
+<body>
+  <test-fixture id="default">
+    <template>
+      <vaadin-list-box>
+        <vaadin-item>Foo</vaadin-item>
+        <vaadin-item>Bar</vaadin-item>
+      </vaadin-list-box>
+    </template>
+  </test-fixture>
+
+  <script>
+    describe(`import warning for vaadin-item`, () => {
+      function isV2() {
+        return window['Polymer'] && window['Polymer']['version'] && window['Polymer']['version'].indexOf('2') === 0;
+      }
+
+      beforeEach(() => fixture('default'));
+
+      it('should warn if not imported', done => {
+        sinon.stub(console, 'warn');
+        setTimeout(() => {
+          expect(console.warn.callCount).to.equal(1);
+          console.warn.restore();
+          done();
+        }, 2001);
+      });
+
+      it('should not warn for present import', (done) => {
+        if (isV2()) {
+          Polymer.Base.importHref(`../../vaadin-item/vaadin-item.html`, () => {
+            sinon.stub(console, 'warn');
+            setTimeout(() => {
+              expect(console.warn.called).to.be.false;
+              console.warn.restore();
+              done();
+            }, 2001);
+          });
+        } else {
+          // importHref is removed in Polymer 3 stable release, skip the test.
+          done();
+        }
+      });
+    });
+  </script>
+</body>

--- a/test/test-suites.js
+++ b/test/test-suites.js
@@ -1,4 +1,5 @@
 
 window.VaadinListBoxSuites = [
+  'import-warning-test.html',
   'list-box-test.html'
 ];


### PR DESCRIPTION
Fixes #52 

Done the same way as in [`vaadin-grid`](https://github.com/vaadin/vaadin-grid/blob/facb31ea3a5466cfe7ad57569638f91d01542645/src/vaadin-grid-dynamic-columns-mixin.html#L123), but without `FlattenedNodesObserver` as `vaadin-item` is going to be used anyway.