### PR TITLE
feat: prepare for TS defs generation [skip ci]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,12 +26,12 @@
   ],
   "dependencies": {
     "polymer": "^2.0.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.5.2",
-    "vaadin-item": "vaadin/vaadin-item#^2.2.0",
-    "vaadin-list-mixin": "vaadin/vaadin-list-mixin#^2.4.0",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
+    "vaadin-item": "vaadin/vaadin-item#^2.3.0-alpha1",
+    "vaadin-list-mixin": "vaadin/vaadin-list-mixin#^2.5.0",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.1.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.0",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.0"
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,9 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ]
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,11 @@
+module.exports = {
+  files: [
+    'vaadin-list-box.js'
+  ],
+  from: [
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
     "src",
     "theme"

--- a/src/vaadin-list-box.html
+++ b/src/vaadin-list-box.html
@@ -59,6 +59,7 @@ This program is available under Apache License Version 2.0, available at https:/
        * @memberof Vaadin
        * @mixes Vaadin.MultiSelectListMixin
        * @mixes Vaadin.ThemableMixin
+       * @mixes Vaadin.ElementMixin
        * @demo demo/index.html
        */
       class ListBoxElement extends Vaadin.ElementMixin(Vaadin.MultiSelectListMixin(Vaadin.ThemableMixin(Polymer.Element))) {
@@ -84,7 +85,10 @@ This program is available under Apache License Version 2.0, available at https:/
         constructor() {
           super();
 
-          /** @protected */
+          /**
+           * @type {Element | null}
+           * @protected
+           */
           this.focused;
         }
 
@@ -95,10 +99,15 @@ This program is available under Apache License Version 2.0, available at https:/
           setTimeout(this._checkImport.bind(this), 2000);
         }
 
+        /**
+         * @return {!HTMLElement}
+         * @protected
+         */
         get _scrollerElement() {
           return this.shadowRoot.querySelector('[part="items"]');
         }
 
+        /** @private */
         _checkImport() {
           var item = this.querySelector('vaadin-item');
           if (item && !(item instanceof Polymer.Element)) {


### PR DESCRIPTION
Fixes #68 

Generated `vaadin-list-box.d.ts` looks like this:

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {MultiSelectListMixin} from '@vaadin/vaadin-list-mixin/vaadin-multi-select-list-mixin.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

declare class ListBoxElement extends
  MultiSelectListMixin(
  ThemableMixin(
  ElementMixin(
  PolymerElement))) {
  focused: Element|null;
  readonly _scrollerElement: HTMLElement;
  ready(): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-list-box": ListBoxElement;
  }
}

export {ListBoxElement};
```