### PR TITLE
Add explicit class selector for list dividers

### DIFF
--- a/theme/lumo/vaadin-list-box-styles.html
+++ b/theme/lumo/vaadin-list-box-styles.html
@@ -64,7 +64,9 @@
 
       /* Easily add section dividers */
 
-      [part="items"] ::slotted(hr) {
+      [part="items"] ::slotted(hr),
+      [part="items"] ::slotted(.vaadin-list-divider) {
+        display: block;
         height: 1px;
         border: 0;
         padding: 0;


### PR DESCRIPTION
The current `hr` selector is problematic because there could be global styles on the page that modify it, and `::slotted()` styles lose in specificity.

Offer an explicit class name API for creating visual dividers.

```html
<vaadin-list-box>
  <vaadin-item>Regular</vaadin-item>
  <vaadin-item>Premium</vaadin-item>
  <hr class="vaadin-list-divider">
  <vaadin-item>VIP</vaadin-item>
</vaadin-list-box>
``