### PR TITLE
chore: update JSDoc for custom events [skip ci]

### DIFF
--- a/src/vaadin-list-box.d.ts
+++ b/src/vaadin-list-box.d.ts
@@ -51,9 +51,9 @@ export interface ListBoxEventMap extends HTMLElementEventMap, ListBoxElementEven
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
- * @fires {CustomEvent<Array<Element>>} items-changed
- * @fires {CustomEvent<number>} selected-changed
- * @fires {CustomEvent<Array<string>>} selected-values-changed
+ * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
+ * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
+ * @fires {CustomEvent} selected-values-changed - Fired when the `selectedValues` property changes.
  */
 declare class ListBoxElement extends MultiSelectListMixin(ThemableMixin(ElementMixin(HTMLElement))) {
   focused: Element | null;

--- a/src/vaadin-list-box.js
+++ b/src/vaadin-list-box.js
@@ -30,9 +30,9 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
- * @fires {CustomEvent<Array<Element>>} items-changed
- * @fires {CustomEvent<number>} selected-changed
- * @fires {CustomEvent<Array<string>>} selected-values-changed
+ * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
+ * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
+ * @fires {CustomEvent} selected-values-changed - Fired when the `selectedValues` property changes.
  *
  * @extends HTMLElement
  * @mixes MultiSelectListMixin


### PR DESCRIPTION
Looks like the event type can not be inferred when using event name autocomplete provided by VSCode plugin. 
So I changed to use `@fires {CustomEvent}` without a type. Also, added the events descriptions.